### PR TITLE
Adjust voting members and set vote to auto-close once passing # reached

### DIFF
--- a/.gitvote.yml
+++ b/.gitvote.yml
@@ -92,7 +92,7 @@ profiles:
     #
     allowed_voters:
       teams: [steering-committee]
-      users: [anajsana,CLewko,Cruzn65,jcleblanc,katiewaz1977,leggetter,tessak22]
+      users: [CLewko,Cruzn65,jcleblanc,katiewaz1977,leggetter,tessak22]
 
     # Periodic status check
     # 
@@ -134,7 +134,7 @@ profiles:
     # 
     # close_on_passing: true
     #
-    close_on_passing: false
+    close_on_passing: true
 
   # Additional configuration profiles
   #


### PR DESCRIPTION
* Removed Ana from voting member list (Linux Foundation member vs. Steering Committee).
* Set auto-close flag to true so that voting will auto-close once enough votes are reached. This will prevent the vote from continuing to stay open for the 7 day period once it already has enough positive votes (or negative / abstain for non-passing)