### PR TITLE
Adjustments to .gitvote

### DIFF
--- a/.gitvote.yml
+++ b/.gitvote.yml
@@ -92,7 +92,6 @@ profiles:
     #
     allowed_voters:
       teams: [steering-committee]
-      users: [CLewko,Cruzn65,jcleblanc,katiewaz1977,leggetter,tessak22]
 
     # Periodic status check
     # 

--- a/.gitvote.yml
+++ b/.gitvote.yml
@@ -61,7 +61,7 @@ profiles:
     #
     # The percentage is calculated based on the number of votes in favor and the
     # number of allowed voters (see allowed_voters field below for more details).
-    pass_threshold: 67
+    pass_threshold: 60
 
     # Allowed voters (optional)
     #


### PR DESCRIPTION
- Remove individual voters and move to SC team vote (allows centralized configuration)
- Adjust to 3/5 majority vote due to having less SC members than original configuration